### PR TITLE
Remove TopMost setting to prevent overlay stealing focus

### DIFF
--- a/CapsLockIndicatorV3/IndicatorOverlay.Designer.cs
+++ b/CapsLockIndicatorV3/IndicatorOverlay.Designer.cs
@@ -81,7 +81,6 @@ namespace CapsLockIndicatorV3
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "IndicatorOverlay";
-            this.TopMost = true;
             this.ResumeLayout(false);
 
 		}


### PR DESCRIPTION
The ShowWithoutActivation and CreateParams properties of IndicatorOverlay prevent focus being taken by the overlay, however, the TopMost property of the form is preventing these from working as intended.