### PR TITLE
Added translatable icons tooltips

### DIFF
--- a/CapsLockIndicatorV3/MainForm.cs
+++ b/CapsLockIndicatorV3/MainForm.cs
@@ -187,6 +187,9 @@ namespace CapsLockIndicatorV3
             enableNumIcon.Text = strings.numLock;
             enableCapsIcon.Text = strings.capsLock;
             enableScrollIcon.Text = strings.scrollLock;
+			numLockIcon.Text = strings.numLockIcon;
+			capsLockIcon.Text = strings.capsLockIcon;
+			scrollLockIcon.Text = strings.scrollLockIcon;
             enableNumInd.Text = string.Format(strings.keyChanged, strings.numLock);
             enableCapsInd.Text = string.Format(strings.keyChanged, strings.capsLock);
             enableScrollInd.Text = string.Format(strings.keyChanged, strings.scrollLock);

--- a/CapsLockIndicatorV3/strings.fr.resx
+++ b/CapsLockIndicatorV3/strings.fr.resx
@@ -281,4 +281,16 @@
     <value>&amp;Mettre à jour maintenant</value>
     <comment>The caption for the "Update now" button. The character after the "&amp;" is the hotkey that is used with the ALT key.</comment>
   </data>
+  <data name="numLockIcon" xml:space="preserve">
+    <value>Verr. num.</value>
+    <comment>The tooltip label for the num lock icon</comment>
+  </data>
+  <data name="scrollLockIcon" xml:space="preserve">
+    <value>Arrêt défil.</value>
+    <comment>The tooltip label for the scroll lock icon</comment>
+  </data>
+  <data name="capsLockIcon" xml:space="preserve">
+    <value>Majuscules</value>
+    <comment>The tooltip label for the caps lock icon</comment>
+  </data>
 </root>

--- a/CapsLockIndicatorV3/strings.resx
+++ b/CapsLockIndicatorV3/strings.resx
@@ -281,4 +281,16 @@
     <value>&amp;Update now</value>
     <comment>The caption for the "Update now" button. The character after the "&amp;" is the hotkey that is used with the ALT key.</comment>
   </data>
+  <data name="numLockIcon" xml:space="preserve">
+    <value>Num lock</value>
+    <comment>The tooltip label for the num lock icon</comment>
+  </data>
+  <data name="scrollLockIcon" xml:space="preserve">
+    <value>Scroll lock</value>
+    <comment>The tooltip label for the scroll lock icon</comment>
+  </data>
+  <data name="capsLockIcon" xml:space="preserve">
+    <value>Caps lock</value>
+    <comment>The tooltip label for the caps lock icon</comment>
+  </data>
 </root>


### PR DESCRIPTION
Warning : I can't compile and test my code.

I only added the new labels to `strings.resx` and `strings.fr.resx`, I don't know if it should also be added to other languages files.

As the icon tooltip must be a short label, I chose to add dedicated labels and not reuse existing ones (in french `Verrouillage numérique` is way too long for the tooltip)