### PR TITLE
Fix Error in Some Systems

### DIFF
--- a/CapsLockIndicatorV3/SettingsManager.cs
+++ b/CapsLockIndicatorV3/SettingsManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -35,7 +35,8 @@ namespace CapsLockIndicatorV3
                 var (type, key) = typeAndKey.Split(new char[] { ':' }, 2, StringSplitOptions.None);
                 var t = GetSettingsType(type);
 
-                Settings[key] = (t, Cast(value, t));
+                if (key != null)
+                    Settings[key] = (t, Cast(value, t));
             }
         }
 
@@ -60,7 +61,8 @@ namespace CapsLockIndicatorV3
                 var (type, key) = typeAndKey.Split(new char[] { ':' }, 2, StringSplitOptions.None);
                 var t = GetSettingsType(type);
 
-                Settings[key] = (t, Cast(value, t));
+                if (key != null)
+                    Settings[key] = (t, Cast(value, t));
             }
         }
 
@@ -181,7 +183,8 @@ namespace CapsLockIndicatorV3
 
         public static void Set(string key, object value)
         {
-            Settings[key] = (value.GetType(), value);
+            if (key != null)
+                Settings[key] = (value.GetType(), value);
         }
 
         public static string GetActualPath()


### PR DESCRIPTION
Error Description:

Aplicação: CapsLockIndicatorV3.exe
Versão do Framework: v4.0.30319
Descrição: O processo foi terminado devido a uma excepção não processada.
Informações da Excepção: System.ArgumentNullException
   em System.ThrowHelper.ThrowArgumentNullException(System.ExceptionArgument)
   em System.Collections.Generic.Dictionary`2[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.ValueTuple`2[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].Insert(System.__Canon, System.ValueTuple`2<System.__Canon,System.__Canon>, Boolean)
   em System.Collections.Generic.Dictionary`2[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.ValueTuple`2[[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.__Canon, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].set_Item(System.__Canon, System.ValueTuple`2<System.__Canon,System.__Canon>)
   em CapsLockIndicatorV3.SettingsManager.LoadUser()
   em CapsLockIndicatorV3.SettingsManager.Load()
   em CapsLockIndicatorV3.Program.Main(System.String[])