### PR TITLE
redundant IsDispose checks to preclude operation on their respective …

### DIFF
--- a/CapsLockIndicatorV3/IndicatorOverlay.cs
+++ b/CapsLockIndicatorV3/IndicatorOverlay.cs
@@ -175,6 +175,8 @@ namespace CapsLockIndicatorV3
 
         private void ClickThroughWindow(double opacity = 1d)
         {
+            if (IsDisposed)
+                return;
             //Opacity = opacity;
             try
             {

--- a/CapsLockIndicatorV3/MainForm.cs
+++ b/CapsLockIndicatorV3/MainForm.cs
@@ -341,19 +341,20 @@ namespace CapsLockIndicatorV3
             }
             else
             {
-                IndicatorOverlay indicatorOverlay = new IndicatorOverlay(
-                      message
-                    , timeOut
-                    , isActive ? SettingsManager.Get<Color>("indBgColourActive") : SettingsManager.Get<Color>("indBgColourInactive")
-                    , isActive ? SettingsManager.Get<Color>("indFgColourActive") : SettingsManager.Get<Color>("indFgColourInactive")
-                    , isActive ? SettingsManager.Get<Color>("indBdColourActive") : SettingsManager.Get<Color>("indBdColourInactive")
-                    , SettingsManager.Get<int>("bdSize")
-                    , SettingsManager.GetOrDefault<Font>("indFont")
-                    , SettingsManager.Get<IndicatorDisplayPosition>("overlayPosition")
-                    , SettingsManager.Get<int>("indOpacity")
-                    , alwaysShow
-                );
-                indicatorOverlay.Show();
+                    IndicatorOverlay indicatorOverlay = new IndicatorOverlay(
+                          message
+                        , timeOut
+                        , isActive ? SettingsManager.Get<Color>("indBgColourActive") : SettingsManager.Get<Color>("indBgColourInactive")
+                        , isActive ? SettingsManager.Get<Color>("indFgColourActive") : SettingsManager.Get<Color>("indFgColourInactive")
+                        , isActive ? SettingsManager.Get<Color>("indBdColourActive") : SettingsManager.Get<Color>("indBdColourInactive")
+                        , SettingsManager.Get<int>("bdSize")
+                        , SettingsManager.GetOrDefault<Font>("indFont")
+                        , SettingsManager.Get<IndicatorDisplayPosition>("overlayPosition")
+                        , SettingsManager.Get<int>("indOpacity")
+                        , alwaysShow
+                    );
+                    if (!indicatorOverlay.IsDisposed)
+                        indicatorOverlay.Show();
             }
         }
         void ShowNoIconsCheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
…fail states.

Before I added the IsDisposed in ShowOverlay, I tested with it just in ClickThroughWindow and it failed, but I would keep it there just for redundancy. if (!indicatorOverlay.IsDisposed) in ShowOverlay seems to be doing the trick.