### PR TITLE
Bugfix: Issue #164 - Wrap path in quotation marks in case of whitespace

### DIFF
--- a/CapsLockIndicatorV3/MainForm.cs
+++ b/CapsLockIndicatorV3/MainForm.cs
@@ -1206,7 +1206,9 @@ namespace CapsLockIndicatorV3
             RegistryKey rk = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", true);
 
             if (startonlogonCheckBox.Checked)
-                rk.SetValue("CapsLock Indicator", Application.ExecutablePath);
+                // Wrap path in quotation marks to avoid issues with directories containing whitespace
+                string ExePath = "\"" + Application.ExecutablePath.ToString() + "\"";
+                rk.SetValue("CapsLock Indicator", ExePath);
             else
                 rk.DeleteValue("CapsLock Indicator", false);
         }


### PR DESCRIPTION
Very minor revision to address issue #164.

```diff
 if (startonlogonCheckBox.Checked)
-    rk.SetValue("CapsLock Indicator", Application.ExecutablePath);
+    // Wrap path in quotation marks to avoid issues with directories containing whitespace
+    string ExePath = "\"" + Application.ExecutablePath.ToString() + "\"";
+    rk.SetValue("CapsLock Indicator", ExePath);
```